### PR TITLE
Ported backend to new Square Node SDK

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -13,6 +13,14 @@
         "tslib": "^1.9.0"
       }
     },
+    "@apimatic/schema": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@apimatic/schema/-/schema-0.4.1.tgz",
+      "integrity": "sha512-KdGp4GaC0sTlcwshahvqZ8OrB/QEM99lxm3sEAo5JgVQP3XH0y/+zeguV8OZhiXRsHERoVZvcI4rKBSHcL84gQ==",
+      "requires": {
+        "lodash.flatten": "^4.4.0"
+      }
+    },
     "@apollo/protobufjs": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@apollo/protobufjs/-/protobufjs-1.0.5.tgz",
@@ -2854,7 +2862,9 @@
     "component-emitter": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
-      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+      "dev": true,
+      "optional": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -2939,11 +2949,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
-    },
-    "cookiejar": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
-      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
     },
     "copy-descriptor": {
       "version": "0.1.1",
@@ -3268,6 +3273,11 @@
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
       "dev": true
+    },
+    "detect-node": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
+      "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw=="
     },
     "dicer": {
       "version": "0.3.0",
@@ -3845,7 +3855,8 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
     },
     "extend-shallow": {
       "version": "3.0.2",
@@ -4197,11 +4208,6 @@
         "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
       }
-    },
-    "formidable": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.2.tgz",
-      "integrity": "sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q=="
     },
     "forwarded": {
       "version": "0.1.2",
@@ -5781,6 +5787,11 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
+    },
+    "lodash.flatmap": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatmap/-/lodash.flatmap-4.5.0.tgz",
+      "integrity": "sha1-74y/QI9uSCaGYzRTBcaswLd4cC4="
     },
     "lodash.flatten": {
       "version": "4.4.0",
@@ -8487,12 +8498,17 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
-    "square-connect": {
-      "version": "6.20201216.0",
-      "resolved": "https://registry.npmjs.org/square-connect/-/square-connect-6.20201216.0.tgz",
-      "integrity": "sha512-QjTsyokZbrq5Mdc2gwZxsefrYmJcXDml/MSO09yBvmyDVrLy42YaR4jO1Kjux/tDMHtD4QJtl0sr1G3D2vl8Dw==",
+    "square": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/square/-/square-8.0.1.tgz",
+      "integrity": "sha512-LE1Jf0DLoUMcNGZhWunTotBC9e7XBexGxmeBmUO13PN+lB+ktJDoyUmGiLHsoD4kUVmKccSYnv/cBnfSzbZyUA==",
       "requires": {
-        "superagent": "3.8.3"
+        "@apimatic/schema": "^0.4.1",
+        "axios": "^0.21.0",
+        "detect-node": "^2.0.4",
+        "form-data": "^3.0.0",
+        "lodash.flatmap": "^4.5.0",
+        "tiny-warning": "^1.0.3"
       }
     },
     "sshpk": {
@@ -8711,48 +8727,6 @@
         }
       }
     },
-    "superagent": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
-      "integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
-      "requires": {
-        "component-emitter": "^1.2.0",
-        "cookiejar": "^2.1.0",
-        "debug": "^3.1.0",
-        "extend": "^3.0.0",
-        "form-data": "^2.3.1",
-        "formidable": "^1.2.0",
-        "methods": "^1.1.1",
-        "mime": "^1.4.1",
-        "qs": "^6.5.1",
-        "readable-stream": "^2.3.5"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "form-data": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
-          "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.6",
-            "mime-types": "^2.1.12"
-          }
-        },
-        "ms": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-        }
-      }
-    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -8815,6 +8789,11 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
+    },
+    "tiny-warning": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
     "tmp": {
       "version": "0.0.33",

--- a/api/package.json
+++ b/api/package.json
@@ -51,7 +51,7 @@
     "node-fetch": "^2.6.1",
     "shopify-api-node": "^3.6.0",
     "shopify-buy": "^2.11.0",
-    "square-connect": "6.20201216.0",
+    "square": "^8.0.1",
     "twilio": "^3.54.1",
     "uuid": "^8.3.2",
     "xml2js": "^0.4.23"

--- a/api/src/models/OrderModel.js
+++ b/api/src/models/OrderModel.js
@@ -20,7 +20,7 @@ const LineItemTC = sc.createObjectTC({
       description:
         'The amount of this item to order. Inputted as String for Square compatibility purposes'
     },
-    catalog_object_id: {
+    catalogObjectId: {
       type: 'String!',
       description: 'The ID of the variant of this item'
     },
@@ -34,10 +34,10 @@ const LineItemTC = sc.createObjectTC({
 const OrderLineItemModifierTC = sc.createObjectTC(`
   type OrderLineItemModifier {
     uid: String
-    catalog_object_id: String,
+    catalogObjectId: String,
     name: String
-    base_price_money: Money
-    total_price_money: Money
+    basePriceMoney: Money
+    totalPriceMoney: Money
   }
 `)
 
@@ -47,11 +47,11 @@ const PreviousLineItemTC = sc.createObjectTC({
   fields: {
     name: 'String',
     quantity: 'String',
-    catalog_object_id: 'String',
-    variation_name: 'String',
+    catalogObjectId: 'String',
+    variationName: 'String',
     modifiers: [OrderLineItemModifierTC],
-    total_money: MoneyTC,
-    total_tax: MoneyTC
+    totalMoney: MoneyTC,
+    totalTax: MoneyTC
   }
 })
 
@@ -148,8 +148,8 @@ const FindOrdersFulfillmentFilterTC = sc.createInputTC({
   name: 'FindOrderFulfillmentFilterInput',
   description: 'Input type for filtering by fulfillment',
   fields: {
-    fulfillment_types: '[String]',
-    fulfillment_states: '[String]'
+    fulfillmentTypes: '[String]',
+    fulfillmentStates: '[String]'
   }
 })
 
@@ -165,10 +165,10 @@ const FilterOrderInputTC = sc.createInputTC({
   name: 'FilterOrderInput',
   description: 'Input type for filter orders',
   fields: {
-    state_filter: FilterOrderStateInputTC,
-    date_time_filter: FindOrdersDateTimeFilterTC,
-    fulfillment_filter: FindOrdersFulfillmentFilterTC,
-    customer_filter: '[String]'
+    stateFilter: FilterOrderStateInputTC,
+    dateTimeFilter: FindOrdersDateTimeFilterTC,
+    fulfillmentFilter: FindOrdersFulfillmentFilterTC,
+    customerFilter: '[String]'
   }
 })
 
@@ -176,8 +176,8 @@ const SortOrderInputTC = sc.createInputTC({
   name: 'SortOrderInput',
   description: 'Input type for sorting orders',
   fields: {
-    sort_field: SortOrderTimeEnumTC,
-    sort_order: SortOrderEnumTC
+    sortField: SortOrderTimeEnumTC,
+    sortOrder: SortOrderEnumTC
   }
 })
 

--- a/api/src/schema/OrderSchema.js
+++ b/api/src/schema/OrderSchema.js
@@ -74,7 +74,7 @@ OrderTC.addResolver({
             catalogObjectId: lineItem.catalogObjectId,
             variationName: lineItem.variationName,
             totalMoney: lineItem.totalMoney,
-            totalTax: lineItem.totalTax,
+            totalTax: lineItem.totalTaxMoney,
             modifiers: lineItem.modifiers?.map(modifier => ({
               uid: modifier.uid,
               catalogObjectId: modifier.catalogObjectId,
@@ -142,120 +142,110 @@ OrderTC.addResolver({
         }
       } = args
 
-      const api = new OrdersApi()
+      const ordersApi = squareClient.ordersApi
 
-      const orderResponse = await api.createOrder({
-        ...new CreateOrderRequest(),
-        idempotency_key: idempotencyKey,
-        order: {
-          location_id: locationId,
-          line_items: lineItems,
-          metadata: {
-            cohenId: cohenId || null,
-            studentId: studentId || null
-          },
-          fulfillments: [
-            {
-              type: 'PICKUP',
-              state: 'PROPOSED',
-              pickup_details: {
-                pickup_at: pickupTime,
-                recipient: {
-                  display_name: recipient.name,
-                  email_address: recipient.email,
-                  phone_number: recipient.phone
+      try {
+        const {
+          result: { order }
+        } = await ordersApi.createOrder({
+          idempotencyKey: idempotencyKey,
+          order: {
+            locationId: locationId,
+            lineItems: lineItems,
+            metadata: {
+              cohenId: cohenId || null,
+              studentId: studentId || null
+            },
+            fulfillments: [
+              {
+                type: 'PICKUP',
+                state: 'PROPOSED',
+                pickupDetails: {
+                  pickupAt: pickupTime,
+                  recipient: {
+                    displayName: recipient.name,
+                    emailAddress: recipient.email,
+                    phoneNumber: recipient.phone
+                  }
                 }
               }
-            }
-          ],
-          state: 'OPEN'
-        }
-      })
+            ],
+            state: 'OPEN'
+          }
+        })
 
-      if (orderResponse.errors) {
-        return new ApolloError(
-          `New order couldn't be created due to reason: ${orderResponse.errors}`
-        )
-      }
+        await OrderTracker.create({
+          status: 'PROPOSED',
+          pickupTime: pickupTime,
+          locationId: locationId,
+          orderId: order.id,
+          paymentType: paymentType
+        })
 
-      OrderTracker.create({
-        status: 'PROPOSED',
-        pickupTime: pickupTime,
-        locationId: locationId,
-        orderId: orderResponse.order.id,
-        paymentType: paymentType
-      })
-
-      const {
-        order: {
-          id,
-          location_id,
-          line_items,
-          total_tax_money,
-          total_discount_money,
-          total_money,
-          state,
-          fulfillments: [first]
-        }
-      } = orderResponse
-
-      console.log(line_items[0].modifiers)
-
-      const CDMOrder = {
-        id: id,
-        merchant: location_id,
-        customer: {
-          name: first.pickup_details.recipient.display_name,
-          email: first.pickup_details.recipient.email_address,
-          phone: first.pickup_details.recipient.phone_number
-        },
-        items: line_items.map(lineItem => ({
-          name: lineItem.name,
-          quantity: lineItem.quantity,
-          catalog_object_id: lineItem.catalog_object_id,
-          variation_name: lineItem.variation_name,
-          total_money: lineItem.total_money,
-          total_tax: lineItem.total_tax,
-          modifiers: lineItem.modifiers?.map(modifier => ({
-            uid: modifier.uid,
-            catalog_object_id: modifier.catalog_object_id,
-            name: modifier.name,
-            base_price_money: modifier.base_price_money,
-            total_price_money: modifier.total_price_money
-          }))
-        })),
-        totalTax: total_tax_money,
-        totalDiscount: total_discount_money,
-        total: total_money,
-        orderStatus: state,
-        cohenId: orderResponse.order.metadata?.cohenId,
-        studentId: orderResponse.order.metadata?.studentId,
-        fulfillment: {
-          uid: first.uid,
-          state: first.state,
-          pickupDetails: {
-            pickupAt: first.pickup_details.pickup_at,
-            placedAt: first.pickup_details.placed_at,
-            recipient: {
-              name: first.pickup_details.recipient.display_name,
-              email: first.pickup_details.recipient.email_address,
-              phone: first.pickup_details.recipient.phone_number
+        const CDMOrder = {
+          id: order.id,
+          merchant: order.locationId,
+          customer: {
+            name: order.fulfillments[0].pickupDetails.recipient.displayName,
+            email: order.fulfillments[0].pickupDetails.recipient.emailAddress,
+            phone: order.fulfillments[0].pickupDetails.recipient.phoneNumber
+          },
+          items: order.lineItems.map(lineItem => ({
+            name: lineItem.name,
+            quantity: lineItem.quantity,
+            catalogObjectId: lineItem.catalogObjectId,
+            variationName: lineItem.variationName,
+            totalMoney: lineItem.totalMoney,
+            totalTax: lineItem.totalTaxMoney,
+            modifiers: lineItem.modifiers?.map(modifier => ({
+              uid: modifier.uid,
+              catalogObjectId: modifier.catalogObjectId,
+              name: modifier.name,
+              basePriceMoney: modifier.basePriceMoney,
+              totalPriceMoney: modifier.totalPriceMoney
+            }))
+          })),
+          totalTax: order.totalTaxMoney,
+          totalDiscount: order.totalDiscountMoney,
+          total: order.totalMoney,
+          orderStatus: order.state,
+          cohenId: order.metadata?.cohenId,
+          studentId: order.metadata?.studentId,
+          fulfillment: {
+            uid: order.fulfillments[0].uid,
+            state: order.fulfillments[0].state,
+            pickupDetails: {
+              pickupAt: order.fulfillments[0].pickupDetails.pickupAt,
+              placedAt: order.fulfillments[0].pickupDetails.placedAt,
+              recipient: {
+                name: order.fulfillments[0].pickupDetails.recipient.displayName,
+                email:
+                  order.fulfillments[0].pickupDetails.recipient.emailAddress,
+                phone: order.fulfillments[0].pickupDetails.recipient.phoneNumber
+              }
             }
           }
         }
+
+        pubsub.publish('orderCreated', {
+          orderCreated: CDMOrder
+        })
+
+        TwilioClient.messages.create({
+          body: 'Your order has been placed.',
+          from: '+13466667153',
+          to: order.fulfillments[0].pickupDetails.recipient.phoneNumber
+        })
+
+        return CDMOrder
+      } catch (error) {
+        if (error instanceof ApiError) {
+          return new ApolloError(
+            `Creating new order on Square failed because ${error.result}`
+          )
+        }
+        return new ApolloError('Something went wrong when creating new order')
       }
-
-      pubsub.publish('orderCreated', {
-        orderCreated: CDMOrder
-      })
-
-      TwilioClient.messages.create({
-        body: 'Your order has been placed.',
-        from: '+13466667153',
-        to: first.pickup_details.recipient.phone_number
-      })
-
-      return CDMOrder
     }
   })
   .addResolver({
@@ -268,7 +258,7 @@ OrderTC.addResolver({
     resolve: async ({ args }) => {
       const {
         orderId,
-        record: { orderStatus, cohenId, studentId, fulfillment }
+        record: { fulfillment }
       } = args
 
       const updatedOrderTracker = await OrderTracker.findOne({
@@ -279,112 +269,107 @@ OrderTC.addResolver({
 
       await updatedOrderTracker.save()
 
-      const api = new OrdersApi()
+      const ordersApi = squareClient.ordersApi
 
-      const batchRetriveOrderResponse = await api.batchRetrieveOrders({
-        order_ids: [orderId]
-      })
+      try {
+        const {
+          result: { order }
+        } = await ordersApi.retrieveOrder(orderId)
 
-      if (batchRetriveOrderResponse.errors) {
-        return new ApolloError(
-          `Order couldn't be updated due to reason: ${batchRetriveOrderResponse.errors}`
-        )
-      }
-
-      const {
-        id,
-        location_id,
-        line_items,
-        total_tax_money,
-        total_discount_money,
-        total_money,
-        state,
-        fulfillments: [first]
-      } = batchRetriveOrderResponse.orders[0]
-
-      const CDMOrder = {
-        id: id,
-        merchant: location_id,
-        customer: {
-          name: first.pickup_details.recipient.display_name,
-          email: first.pickup_details.recipient.email_address,
-          phone: first.pickup_details.recipient.phone_number
-        },
-        items: line_items.map(lineItem => ({
-          name: lineItem.name,
-          quantity: lineItem.quantity,
-          catalog_object_id: lineItem.catalog_object_id,
-          variation_name: lineItem.variation_name,
-          total_money: lineItem.total_money,
-          total_tax: lineItem.total_tax,
-          modifiers: lineItem.modifiers?.map(modifier => ({
-            uid: modifier.uid,
-            catalog_object_id: modifier.catalog_object_id,
-            name: modifier.name,
-            base_price_money: modifier.base_price_money,
-            total_price_money: modifier.total_price_money
-          }))
-        })),
-        totalTax: total_tax_money,
-        totalDiscount: total_discount_money,
-        total: total_money,
-        orderStatus: state,
-        cohenId: cohenId,
-        studentId: studentId,
-        fulfillment: {
-          uid: first.uid,
-          state: updatedOrderTracker.status,
-          pickupDetails: {
-            pickupAt: first.pickup_details.pickup_at,
-            placedAt: first.pickup_details.placed_at,
-            recipient: {
-              name: first.pickup_details.recipient.display_name,
-              email: first.pickup_details.recipient.email_address,
-              phone: first.pickup_details.recipient.phone_number
+        const CDMOrder = {
+          id: order.id,
+          merchant: order.locationId,
+          customer: {
+            name: order.fulfillments[0].pickupDetails.recipient.displayName,
+            email: order.fulfillments[0].pickupDetails.recipient.emailAddress,
+            phone: order.fulfillments[0].pickupDetails.recipient.phoneNumber
+          },
+          items: order.lineItems.map(lineItem => ({
+            name: lineItem.name,
+            quantity: lineItem.quantity,
+            catalogObjectId: lineItem.catalogObjectId,
+            variationName: lineItem.variationName,
+            totalMoney: lineItem.totalMoney,
+            totalTax: lineItem.totalTaxMoney,
+            modifiers: lineItem.modifiers?.map(modifier => ({
+              uid: modifier.uid,
+              catalogObjectId: modifier.catalogObjectId,
+              name: modifier.name,
+              basePriceMoney: modifier.basePriceMoney,
+              totalPriceMoney: modifier.totalPriceMoney
+            }))
+          })),
+          totalTax: order.totalTaxMoney,
+          totalDiscount: order.totalDiscountMoney,
+          total: order.totalMoney,
+          orderStatus: order.state,
+          cohenId: order.metadata?.cohenId,
+          studentId: order.metadata?.studentId,
+          fulfillment: {
+            uid: order.fulfillments[0].uid,
+            state: updatedOrderTracker.status,
+            pickupDetails: {
+              pickupAt: order.fulfillments[0].pickupDetails.pickupAt,
+              placedAt: order.fulfillments[0].pickupDetails.placedAt,
+              recipient: {
+                name: order.fulfillments[0].pickupDetails.recipient.displayName,
+                email:
+                  order.fulfillments[0].pickupDetails.recipient.emailAddress,
+                phone: order.fulfillments[0].pickupDetails.recipient.phoneNumber
+              }
             }
           }
         }
+
+        pubsub.publish('orderUpdated', {
+          orderUpdated: CDMOrder
+        })
+
+        switch (updatedOrderTracker.status) {
+          case 'PREPARED':
+            TwilioClient.messages.create({
+              body:
+                'Your recent order has been prepared. Please go to the pickup location',
+              from: '+13466667153',
+              to: order.fulfillments[0].pickupDetails.recipient.phoneNumber
+            })
+            break
+          case 'COMPLETED':
+            TwilioClient.messages.create({
+              body:
+                'Your order has been picked up. If you did not do this, please contact the vendor directly.',
+              from: '+13466667153',
+              to: order.fulfillments[0].pickupDetails.recipient.phoneNumber
+            })
+            break
+          case 'CANCELED':
+            TwilioClient.messages.create({
+              body:
+                'Your order has been cancelled. To reorder, please visit https://hedwig.riceapps.org/',
+              from: '+13466667153',
+              to: order.fulfillments[0].pickupDetails.recipient.phoneNumber
+            })
+            break
+          default:
+            TwilioClient.messages.create({
+              body:
+                'Your order has been updated. Please check https://hedwig.riceapps.org/ for more details',
+              from: '+13466667153',
+              to: order.fulfillments[0].pickupDetails.recipient.phoneNumber
+            })
+        }
+
+        return CDMOrder
+      } catch (error) {
+        if (error instanceof ApiError) {
+          return new ApolloError(
+            `Updating order ${orderId} using Square failed because ${error.result}`
+          )
+        }
+        return new ApolloError(
+          `Something went wrong when updating order ${orderId}`
+        )
       }
-
-      pubsub.publish('orderUpdated', {
-        orderUpdated: CDMOrder
-      })
-
-      switch (updatedOrderTracker.status) {
-        case 'PREPARED':
-          TwilioClient.messages.create({
-            body:
-              'Your recent order has been prepared. Please go to the pickup location',
-            from: '+13466667153',
-            to: first.pickup_details.recipient.phone_number
-          })
-          break
-        case 'COMPLETED':
-          TwilioClient.messages.create({
-            body:
-              'Your order has been picked up. If you did not do this, please contact the vendor directly.',
-            from: '+13466667153',
-            to: first.pickup_details.recipient.phone_number
-          })
-          break
-        case 'CANCELED':
-          TwilioClient.messages.create({
-            body:
-              'Your order has been cancelled. To reorder, please visit https://hedwig.riceapps.org/',
-            from: '+13466667153',
-            to: first.pickup_details.recipient.phone_number
-          })
-          break
-        default:
-          TwilioClient.messages.create({
-            body:
-              'Your order has been updated. Please check https://hedwig.riceapps.org/ for more details',
-            from: '+13466667153',
-            to: first.pickup_details.recipient.phone_number
-          })
-      }
-
-      return CDMOrder
     }
   })
 

--- a/api/src/schema/OrderSchema.js
+++ b/api/src/schema/OrderSchema.js
@@ -153,8 +153,8 @@ OrderTC.addResolver({
             locationId: locationId,
             lineItems: lineItems,
             metadata: {
-              cohenId: cohenId || null,
-              studentId: studentId || null
+              cohenId: cohenId || "N/A",
+              studentId: studentId || "N/A"
             },
             fulfillments: [
               {

--- a/api/src/schema/ProductSchema.js
+++ b/api/src/schema/ProductSchema.js
@@ -34,7 +34,7 @@ ItemTC.addResolver({
 
       // Define functions for getting category and modifier list data from id
       const categoryId2Name = id =>
-        categories.find(category => category.id === id).category_data.name
+        categories.find(category => category.id === id).categoryData.name
       const modifierListId2Data = id =>
         modifierLists.find(modifierList => modifierList.id === id)
 
@@ -144,6 +144,7 @@ ItemTC.addResolver({
           `Getting Square catalog failed because ${error.result}`
         )
       }
+      console.log(error)
       return new ApolloError(`Something went wrong when getting Square catalog`)
     }
   }
@@ -579,7 +580,7 @@ ItemTC.addResolver({
         const {
           result: { objects: catalogObjects }
         } = await catalogApi.batchRetrieveCatalogObjects({
-          object_ids: products
+          objectIds: products
         })
 
         const upsertBatchObjects = catalogObjects.map(product => ({
@@ -618,7 +619,7 @@ ItemTC.addResolver({
 
         // Define functions for getting category and modifier list data from id
         const categoryId2Name = id =>
-          categories.find(category => category.id === id).category_data.name
+          categories.find(category => category.id === id).categoryData.name
         const modifierListId2Data = id =>
           modifierLists.find(modifierList => modifierList.id === id)
 

--- a/api/src/schema/ProductSchema.js
+++ b/api/src/schema/ProductSchema.js
@@ -1,13 +1,9 @@
-import {
-  BatchRetrieveCatalogObjectsRequest,
-  CatalogApi,
-  ListCatalogRequest,
-  UpsertCatalogObjectRequest
-} from 'square-connect'
 import { ApolloError } from 'apollo-server-express'
+import { ApiError } from 'square'
 import { v4 as uuid } from 'uuid'
 import { ItemTC } from '../models'
 import { DataSourceEnumTC } from '../models/CommonModels'
+import squareClient from '../square'
 import { pubsub } from '../utils/pubsub'
 
 ItemTC.addResolver({
@@ -21,134 +17,135 @@ ItemTC.addResolver({
     // Extract vendor name from args
     const { dataSource } = args
 
-    // Step 1: Make Square Request for Catalog
-    const api = new CatalogApi()
-    const listCatalogBody = new ListCatalogRequest()
-    listCatalogBody.types = 'ITEM,CATEGORY,MODIFIER_LIST'
-    const catalogResponse = await api.listCatalog(listCatalogBody)
-    // await fs.writeFile('example_catalog.json', JSON.stringify(catalogResponse), {}, () => console.log("Hi"));
+    const catalogApi = squareClient.catalogApi
 
-    const { objects } = catalogResponse
-
-    // Step 1.5: Filter objects into distinct sets
-    const categories = objects.filter(object => object.type === 'CATEGORY')
-    const modifierLists = objects.filter(
-      object => object.type === 'MODIFIER_LIST'
-    )
-    const items = objects.filter(object => object.type === 'ITEM')
-
-    // Step 1.7: Extract category names from categories
-    const categoryId2Name = id =>
-      categories.find(category => category.id === id).category_data.name
-    const modifierListId2Data = id =>
-      modifierLists.find(modifierList => modifierList.id === id)
-
-    // Step 2: Transform data into CMD
-    return items.map(item => {
+    try {
+      // Make Square request for catalog
       const {
-        id: itemId,
-        item_data: {
-          name: baseItemName,
-          description: baseItemDescription,
-          variations,
-          modifier_list_info,
-          category_id
-        },
-        custom_attribute_values: {
-          is_available: { boolean_value: isAvailable }
-        }
-      } = item
+        result: { objects }
+      } = await catalogApi.listCatalog(undefined, 'ITEM,CATEGORY,MODIFIER_LIST')
 
-      // Step 2.25: Replace category IDs with names
-      const categoryName = categoryId2Name(category_id)
+      // Filter objects into distinct sets
+      const categories = objects.filter(object => object.type === 'CATEGORY')
+      const modifierLists = objects.filter(
+        object => object.type === 'MODIFIER_LIST'
+      )
+      const items = objects.filter(object => object.type === 'ITEM')
 
-      const returnedVariants = variations.map(variant => {
+      // Define functions for getting category and modifier list data from id
+      const categoryId2Name = id =>
+        categories.find(category => category.id === id).category_data.name
+      const modifierListId2Data = id =>
+        modifierLists.find(modifierList => modifierList.id === id)
+
+      // Get fields for GraphQL response
+      return items.map(item => {
         const {
-          id: itemVariationId,
-          item_variation_data: {
-            item_id: parentItemId,
-            name: itemVariationName,
-            price_money
-          }
-        } = variant
-
-        return {
-          dataSourceId: itemVariationId,
-          parentItemId,
-          // Some variants do not have an associated price
-          price: {
-            amount: price_money ? price_money.amount : 0,
-            currency: price_money ? price_money.currency : 'USD'
+          id: itemId,
+          itemData: {
+            name: baseItemName,
+            description: baseItemDescription,
+            variations,
+            modifierListInfo,
+            categoryId
           },
-          // From interface
-          name: itemVariationName,
-          dataSource,
-          merchant: ''
-        }
-      })
-
-      const modifierLists = modifier_list_info
-        ? modifier_list_info.map(info => [
-            modifierListId2Data(info.modifier_list_id),
-            info.min_selected_modifiers,
-            info.max_selected_modifiers
-          ])
-        : []
-
-      const returnedModifierLists = modifierLists.map(modifierList => {
-        const {
-          id: parentListId,
-          modifier_list_data: {
-            name: modifierListName,
-            selection_type,
-            modifiers
+          customAttributeValues: {
+            is_available: { booleanValue: isAvailable }
           }
-        } = modifierList[0]
+        } = item
 
-        const returnedModifiers = modifiers.map(modifier => {
+        const categoryName = categoryId2Name(categoryId)
+
+        const returnedVariants = variations.map(variant => {
           const {
-            id: modifierId,
-            modifier_data: { name: modifierName, modifier_list_id, price_money }
-          } = modifier
+            id: itemVariationId,
+            itemVariationData: {
+              itemId: parentItemId,
+              name: itemVariationName,
+              priceMoney
+            }
+          } = variant
 
           return {
-            dataSourceId: modifierId,
-            parentListId: modifier_list_id,
-            // Some modifiers do not have an associated price
+            dataSourceId: itemVariationId,
+            parentItemId,
             price: {
-              amount: price_money ? price_money.amount : 0,
-              currency: price_money ? price_money.currency : 'USD'
+              amount: priceMoney ? priceMoney.amount : 0,
+              currency: priceMoney ? priceMoney.currency : 'USD'
             },
-            // For interface
-            name: modifierName,
+            name: itemVariationName,
             dataSource,
             merchant: ''
           }
         })
 
+        const modifierLists = modifierListInfo
+          ? modifierListInfo.map(info => ({
+              data: modifierListId2Data(info.modifierListId),
+              min: info.minSelectedModifiers,
+              max: info.maxSelectedModifiers
+            }))
+          : []
+
+        const returnedModifierLists = modifierLists.map(modifierList => {
+          const {
+            id: parentListId,
+            modifierListData: {
+              name: modifierListName,
+              selectionType,
+              modifiers
+            }
+          } = modifierList.data
+
+          const returnedModifiers = modifiers.map(modifier => {
+            const {
+              id: modifierId,
+              modifierData: { name: modifierName, modifierListId, priceMoney }
+            } = modifier
+
+            return {
+              dataSourceId: modifierId,
+              parentListId: modifierListId,
+              price: {
+                amount: priceMoney ? priceMoney.amount : 0,
+                currency: priceMoney ? priceMoney.currency : 'USD'
+              },
+              name: modifierName,
+              dataSource,
+              merchant: ''
+            }
+          })
+
+          return {
+            dataSourceId: parentListId,
+            name: modifierListName,
+            selectionType: selectionType,
+            modifiers: returnedModifiers,
+            minModifiers: modifierList.min,
+            maxModifiers: modifierList.max
+          }
+        })
+
         return {
-          dataSourceId: parentListId,
-          name: modifierListName,
-          selectionType: selection_type,
-          modifiers: returnedModifiers,
-          minModifiers: modifierList[1],
-          maxModifiers: modifierList[2]
+          dataSourceId: itemId,
+          category: categoryName,
+          variants: returnedVariants,
+          modifierLists: returnedModifierLists,
+          dataSource,
+          name: baseItemName,
+          description: baseItemDescription,
+          merchant: '',
+          isAvailable: isAvailable
         }
       })
-
-      return {
-        dataSourceId: itemId,
-        category: categoryName,
-        variants: returnedVariants,
-        modifierLists: returnedModifierLists,
-        // From interface
-        dataSource,
-        name: baseItemName,
-        description: baseItemDescription,
-        merchant: '',
-        isAvailable: isAvailable
+    } catch (error) {
+      if (error instanceof ApiError) {
+        return new ApolloError(
+          `Getting Square catalog failed because ${error.result}`
+        )
       }
-    })
+      return new ApolloError(`Something went wrong when getting Square catalog`)
+    }
   }
 })
   .addResolver({
@@ -164,135 +161,134 @@ ItemTC.addResolver({
       // Extract data source to interact with as well as ID of product (as used inside data source)
       const { dataSource, dataSourceId } = args
 
-      // Step 1: Make request to Square to fetch this item ID
-      const api = new CatalogApi()
-      const retrievalResponse = await api.retrieveCatalogObject(dataSourceId)
+      const catalogApi = squareClient.catalogApi
 
-      if (retrievalResponse.errors) {
-        return new ApolloError(
-          `Encountered the following errors while create payment: ${retrievalResponse.errors}`
-        )
-      }
-
-      const { object } = retrievalResponse
-
-      // Step 2: Process Square Item into Common Data Model
-      const {
-        item_data: {
-          name: baseItemName,
-          description: baseItemDescription,
-          variations,
-          modifier_list_info
-        },
-        custom_attribute_values: {
-          is_available: { boolean_value: isAvailable }
-        }
-      } = object
-
-      // Parse variation data
-      const returnedVariants = variations.map(variant => {
+      try {
         const {
-          id: itemVariationId,
-          item_variation_data: {
-            item_id: parentItemId,
-            name: itemVariationName,
-            price_money
-          }
-        } = variant
+          result: { object }
+        } = await catalogApi.retrieveCatalogObject(dataSourceId)
 
-        return {
-          dataSourceId: itemVariationId,
-          parentItemId,
-          price: {
-            amount: price_money ? price_money.amount : -1,
-            currency: price_money ? price_money.currency : -1
+        const {
+          itemData: {
+            name: baseItemName,
+            description: baseItemDescription,
+            variations,
+            modifierListInfo
           },
-          // From interface
-          name: itemVariationName,
-          dataSource,
-          merchant: ''
-        }
-      })
+          customAttributeValues: {
+            is_available: { booleanValue: isAvailable }
+          }
+        } = object
 
-      // Get all modifier list IDs that correspond to this item
-      // this mapping below is breaking because the modifier_list_info is null
-      let returnedModifierLists
-      if (modifier_list_info) {
-        const modifier_list_ids = modifier_list_info.map(
-          info => info.modifier_list_id
-        )
-        // Create request body for batch retrieval, using modifier list IDs
-        const modifierRequestBody = new BatchRetrieveCatalogObjectsRequest()
-        modifierRequestBody.object_ids = modifier_list_ids
-
-        // Make request for modifier lists
-        const modifierListsData = await api.batchRetrieveCatalogObjects(
-          modifierRequestBody
-        )
-        const { objects: modifierObjects } = modifierListsData
-
-        // Parse modifier lists data
-        returnedModifierLists = modifierObjects.map(modifierList => {
+        const returnedVariants = variations.map(variant => {
           const {
-            id: parentListId,
-            modifier_list_data: {
-              name: modifierListName,
-              selection_type,
-              modifiers
+            id: itemVariationId,
+            itemVariationData: {
+              itemId: parentItemId,
+              name: itemVariationName,
+              priceMoney
             }
-          } = modifierList
-
-          const parentListInfo = modifier_list_info.filter(
-            info => info.modifier_list_id === parentListId
-          )[0]
-
-          const returnedModifiers = modifiers.map(modifier => {
-            const {
-              id,
-              modifier_data: {
-                name: modifierName,
-                modifier_list_id,
-                price_money
-              }
-            } = modifier
-
-            return {
-              dataSourceId: id,
-              parentListId: modifier_list_id,
-              // Some modifiers do not have an associated price
-              price: {
-                amount: price_money ? price_money.amount : 0,
-                currency: price_money ? price_money.currency : 'USD'
-              },
-              // For interface
-              name: modifierName,
-              dataSource,
-              merchant: ''
-            }
-          })
+          } = variant
 
           return {
-            dataSourceId: parentListId,
-            name: modifierListName,
-            selectionType: selection_type,
-            modifiers: returnedModifiers,
-            minModifiers: parentListInfo.min_selected_modifiers,
-            maxModifiers: parentListInfo.max_selected_modifiers
+            dataSourceId: itemVariationId,
+            parentItemId,
+            price: {
+              amount: priceMoney ? priceMoney.amount : 0,
+              currency: priceMoney ? priceMoney.currency : 'USD'
+            },
+            name: itemVariationName,
+            dataSource,
+            merchant: ''
           }
         })
-      }
 
-      // Step 3: Return product in common data model format
-      return {
-        dataSourceId,
-        variants: returnedVariants,
-        modifierLists: returnedModifierLists || [],
-        // From interface
-        dataSource,
-        name: baseItemName,
-        description: baseItemDescription,
-        merchant: '',
-        isAvailable: isAvailable
+        let returnedModifierLists = null
+
+        if (modifierListInfo) {
+          const modifierListIds = modifierListInfo.map(
+            info => info.modifierListId
+          )
+
+          try {
+            const {
+              result: { objects: modifierObjects }
+            } = await catalogApi.batchRetrieveCatalogObjects({
+              objectIds: modifierListIds
+            })
+
+            returnedModifierLists = modifierObjects.map(modifierList => {
+              const {
+                id: parentListId,
+                modifierListData: {
+                  name: modifierListName,
+                  selectionType,
+                  modifiers
+                }
+              } = modifierList
+
+              const parentListInfo = modifierListInfo.find(
+                info => info.modifierListId === parentListId
+              )
+
+              const returnedModifiers = modifiers.map(modifier => {
+                const {
+                  id,
+                  modifierData: {
+                    name: modifierName,
+                    modifierListId,
+                    priceMoney
+                  }
+                } = modifier
+
+                return {
+                  dataSourceId: id,
+                  parentListId: modifierListId,
+                  price: {
+                    amount: priceMoney ? priceMoney.amount : 0,
+                    currency: priceMoney ? priceMoney.currency : 'USD'
+                  },
+                  name: modifierName,
+                  dataSource,
+                  merchant: ''
+                }
+              })
+
+              return {
+                dataSourceId: parentListId,
+                name: modifierListName,
+                selectionType: selectionType,
+                modifiers: returnedModifiers,
+                minModifiers: parentListInfo.minSelectedModifiers,
+                maxModifiers: parentListInfo.maxSelectedModifiers
+              }
+            })
+          } catch (error) {
+            returnedModifierLists = null
+          }
+        }
+
+        return {
+          dataSourceId,
+          variants: returnedVariants,
+          modifierLists: returnedModifierLists || [],
+          // From interface
+          dataSource,
+          name: baseItemName,
+          description: baseItemDescription,
+          merchant: '',
+          isAvailable: isAvailable
+        }
+      } catch (error) {
+        if (error instanceof ApiError) {
+          return new ApolloError(
+            `Retrieving item ${dataSourceId} from Square failed because ${error.result}`
+          )
+        }
+
+        return new ApolloError(
+          `Something went wrong when retrieving item ${dataSourceId}`
+        )
       }
     }
   })
@@ -305,20 +301,25 @@ ItemTC.addResolver({
     resolve: async ({ args }) => {
       const { productId } = args
 
-      const api = new CatalogApi()
+      const catalogApi = squareClient.catalogApi
 
-      const retrieveCatalogObjectResponse = await api.retrieveCatalogObject(
-        productId
-      )
+      try {
+        const {
+          result: { object }
+        } = await catalogApi.retrieveCatalogObject(productId)
 
-      if (retrieveCatalogObjectResponse.errors) {
+        return object.customAttributeValues.is_available.booleanValue
+      } catch (error) {
+        if (error instanceof ApiError) {
+          return new ApolloError(
+            `Getting availability for item ${productId} failed because ${error.result}`
+          )
+        }
+
         return new ApolloError(
-          `Updating availability failed: ${retrieveCatalogObjectResponse.errors}`
+          `Something went wrong getting availability for item ${productId}`
         )
       }
-
-      return retrieveCatalogObjectResponse.object.custom_attribute_values
-        .is_available.boolean_value
     }
   })
   .addResolver({
@@ -330,185 +331,198 @@ ItemTC.addResolver({
     resolve: async ({ args }) => {
       const { productIds } = args
 
-      const api = new CatalogApi()
+      const catalogApi = squareClient.catalogApi
 
-      const batchRetrieveResponse = await api.batchRetrieveCatalogObjects({
-        object_ids: productIds
-      })
+      try {
+        const {
+          result: { objects }
+        } = await catalogApi.batchRetrieveCatalogObjects({
+          objectIds: productIds
+        })
 
-      if (batchRetrieveResponse.errors) {
+        return objects.every(
+          value => value.customAttributeValues.is_available.booleanValue
+        )
+      } catch (error) {
+        if (error instanceof ApiError) {
+          return new ApolloError(
+            `Batch retrieve availabilities from Square failed because ${error.result}`
+          )
+        }
+
         return new ApolloError(
-          `Batch retrieving availabilities failed: ${batchRetrieveResponse.errors}`
+          `Something went wrong batch retrieving availabilities`
         )
       }
-
-      return batchRetrieveResponse.objects.every(
-        value => value.custom_attribute_values.is_available.boolean_value
-      )
     }
   })
   .addResolver({
     name: 'setAvailability',
     args: {
-      idempotencyKey: 'String!',
       productId: 'String!',
       isItemAvailable: 'Boolean!',
       dataSource: DataSourceEnumTC
     },
     type: ItemTC,
     resolve: async ({ args }) => {
-      const { idempotencyKey, productId, isItemAvailable, dataSource } = args
+      const { productId, isItemAvailable, dataSource } = args
 
-      const api = new CatalogApi()
+      const catalogApi = squareClient.catalogApi
 
-      const retrieveCatalogObjectResponse = await api.retrieveCatalogObject(
-        productId
-      )
+      try {
+        const {
+          result: {
+            object: { version, itemData }
+          }
+        } = await catalogApi.retrieveCatalogObject(productId)
 
-      const upsertCatalogObjectBody = new UpsertCatalogObjectRequest()
-
-      upsertCatalogObjectBody.idempotency_key = idempotencyKey
-      upsertCatalogObjectBody.object = {}
-      upsertCatalogObjectBody.object.id = productId
-      upsertCatalogObjectBody.object.type = 'ITEM'
-      upsertCatalogObjectBody.object.version =
-        retrieveCatalogObjectResponse.object.version
-      ;(upsertCatalogObjectBody.object.item_data =
-        retrieveCatalogObjectResponse.object.item_data),
-        (upsertCatalogObjectBody.object.custom_attribute_values = {
-          is_available: {
-            name: 'Is it available?',
-            key: 'is_available',
-            custom_attribute_definition_id: '7XN45PC5N5ALEEWG6TV6I7YJ',
-            type: 'BOOLEAN',
-            boolean_value: isItemAvailable
+        const {
+          result: { catalogObject }
+        } = await catalogApi.upsertCatalogObject({
+          idempotencyKey: uuid(),
+          object: {
+            id: productId,
+            type: 'ITEM',
+            version: version,
+            itemData: itemData,
+            customAttributeValues: {
+              is_available: {
+                name: 'Is it available?',
+                key: 'is_available',
+                customAttributeDefinitionId: '7XN45PC5N5ALEEWG6TV6I7YJ',
+                type: 'BOOLEAN',
+                booleanValue: isItemAvailable
+              }
+            }
           }
         })
 
-      const upsertCatalogItemResponse = await api.upsertCatalogObject(
-        upsertCatalogObjectBody
-      )
-
-      if (upsertCatalogItemResponse.errors) {
-        return new ApolloError(
-          `Updating availability failed: ${upsertCatalogItemResponse.errors}`
-        )
-      }
-
-      const {
-        item_data: {
-          name: baseItemName,
-          description: baseItemDescription,
-          variations,
-          modifier_list_info
-        }
-      } = upsertCatalogItemResponse.catalog_object
-
-      // Parse variation data
-      const returnedVariants = variations.map(variant => {
         const {
-          id: itemVariationId,
-          item_variation_data: {
-            item_id: parentItemId,
-            name: itemVariationName,
-            price_money
-          }
-        } = variant
-
-        return {
-          dataSourceId: itemVariationId,
-          parentItemId,
-          price: {
-            amount: price_money.amount,
-            currency: price_money.currency
+          itemData: {
+            name: baseItemName,
+            description: baseItemDescription,
+            variations,
+            modifierListInfo
           },
-          // From interface
-          name: itemVariationName,
-          dataSource,
-          merchant: ''
-        }
-      })
-
-      // Get all modifier list IDs that correspond to this item
-      const modifier_list_ids = modifier_list_info.map(
-        info => info.modifier_list_id
-      )
-      // Create request body for batch retrieval, using modifier list IDs
-      const modifierRequestBody = new BatchRetrieveCatalogObjectsRequest()
-      modifierRequestBody.object_ids = modifier_list_ids
-
-      // Make request for modifier lists
-      const modifierListsData = await api.batchRetrieveCatalogObjects(
-        modifierRequestBody
-      )
-      const { objects: modifierObjects } = modifierListsData
-
-      // Parse modifier lists data
-      const returnedModifierLists = modifierObjects.map(modifierList => {
-        const {
-          id: parentListId,
-          modifier_list_data: {
-            name: modifierListName,
-            selection_type,
-            modifiers
+          customAttributeValues: {
+            is_available: { booleanValue: isAvailable }
           }
-        } = modifierList
+        } = catalogObject
 
-        const parentListInfo = modifier_list_info.filter(
-          info => info.modifier_list_id === parentListId
-        )[0]
-
-        const returnedModifiers = modifiers.map(modifier => {
+        const returnedVariants = variations.map(variant => {
           const {
-            id,
-            modifier_data: { name: modifierName, modifier_list_id, price_money }
-          } = modifier
+            id: itemVariationId,
+            itemVariationData: {
+              itemId: parentItemId,
+              name: itemVariationName,
+              priceMoney
+            }
+          } = variant
 
           return {
-            dataSourceId: id,
-            parentListId: modifier_list_id,
-            // Some modifiers do not have an associated price
+            dataSourceId: itemVariationId,
+            parentItemId,
             price: {
-              amount: price_money ? price_money.amount : 0,
-              currency: price_money ? price_money.currency : 'USD'
+              amount: priceMoney ? priceMoney.amount : 0,
+              currency: priceMoney ? priceMoney.currency : 'USD'
             },
-            // For interface
-            name: modifierName,
+            name: itemVariationName,
             dataSource,
             merchant: ''
           }
         })
 
-        return {
-          dataSourceId: parentListId,
-          name: modifierListName,
-          selectionType: selection_type,
-          modifiers: returnedModifiers,
-          minModifiers: parentListInfo.min_selected_modifiers,
-          maxModifiers: parentListInfo.max_selected_modifiers
+        let returnedModifierLists = null
+
+        if (modifierListInfo) {
+          const modifierListIds = modifierListInfo.map(
+            info => info.modifierListId
+          )
+
+          try {
+            const {
+              result: { objects: modifierObjects }
+            } = await catalogApi.batchRetrieveCatalogObjects({
+              objectIds: modifierListIds
+            })
+
+            returnedModifierLists = modifierObjects.map(modifierList => {
+              const {
+                id: parentListId,
+                modifierListData: {
+                  name: modifierListName,
+                  selectionType,
+                  modifiers
+                }
+              } = modifierList
+
+              const parentListInfo = modifierListInfo.find(
+                info => info.modifierListId === parentListId
+              )
+
+              const returnedModifiers = modifiers.map(modifier => {
+                const {
+                  id,
+                  modifierData: {
+                    name: modifierName,
+                    modifierListId,
+                    priceMoney
+                  }
+                } = modifier
+
+                return {
+                  dataSourceId: id,
+                  parentListId: modifierListId,
+                  price: {
+                    amount: priceMoney ? priceMoney.amount : 0,
+                    currency: priceMoney ? priceMoney.currency : 'USD'
+                  },
+                  name: modifierName,
+                  dataSource,
+                  merchant: ''
+                }
+              })
+
+              return {
+                dataSourceId: parentListId,
+                name: modifierListName,
+                selectionType: selectionType,
+                modifiers: returnedModifiers,
+                minModifiers: parentListInfo.minSelectedModifiers,
+                maxModifiers: parentListInfo.maxSelectedModifiers
+              }
+            })
+          } catch (error) {
+            returnedModifierLists = null
+          }
         }
-      })
 
-      // Step 3: Return product in common data model format
-      const CDMProduct = {
-        dataSourceId: productId,
-        variants: returnedVariants,
-        modifierLists: returnedModifierLists,
-        // From interface
-        dataSource,
-        name: baseItemName,
-        description: baseItemDescription,
-        merchant: '',
-        isAvailable:
-          upsertCatalogItemResponse.catalog_object.custom_attribute_values
-            .is_available.boolean_value
+        const CDMProduct = {
+          dataSourceId: productId,
+          variants: returnedVariants,
+          modifierLists: returnedModifierLists || [],
+          // From interface
+          dataSource,
+          name: baseItemName,
+          description: baseItemDescription,
+          merchant: '',
+          isAvailable: isAvailable
+        }
+
+        pubsub.publish('availabilityChanged', {
+          availabilityChanged: CDMProduct
+        })
+
+        return CDMProduct
+      } catch (error) {
+        if (error instanceof ApiError) {
+          return new ApolloError(
+            `Setting availability using Square failed because ${error.result}`
+          )
+        }
+
+        return new ApolloError(`Something went wrong setting availability`)
       }
-
-      pubsub.publish('availabilityChanged', {
-        availabilityChanged: CDMProduct
-      })
-
-      return CDMProduct
     }
   })
   .addResolver({
@@ -518,29 +532,35 @@ ItemTC.addResolver({
       merchantId: 'String!'
     },
     resolve: async ({ args }) => {
-      const api = new CatalogApi()
+      const catalogApi = squareClient.catalogApi
 
-      const upsertCatalogItemResponse = await api.upsertCatalogObject({
-        idempotency_key: idempotencyKey,
-        object: {
-          id: '#is_available',
-          type: 'CUSTOM_ATTRIBUTE_DEFINITION',
-          custom_attribute_definition_data: {
-            allowed_object_types: ['ITEM', 'ITEM_VARIATION'],
-            name: 'is_available',
-            type: 'BOOLEAN',
-            key: 'is_available'
+      try {
+        const {
+          result: { catalogObject }
+        } = await catalogApi.upsertCatalogObject({
+          idempotencyKey: uuid(),
+          object: {
+            id: '#is_available',
+            type: 'CUSTOM_ATTRIBUTE_DEFINITION',
+            customAttributeValues: {
+              allowedObjectTypes: ['ITEM', 'ITEM_VARIATION'],
+              name: 'is_available',
+              type: 'BOOLEAN',
+              key: 'is_available'
+            }
           }
+        })
+
+        return catalogObject.id
+      } catch (error) {
+        if (error instanceof ApiError) {
+          return new ApolloError(
+            `Creating availability toggle using Square failed because ${error.result}`
+          )
         }
-      })
 
-      if (upsertCatalogItemResponse.errors) {
-        return new ApolloError(
-          `Creating availability toggle failed: ${upsertCatalogItemResponse.errors}`
-        )
+        return new ApolloError(`Something went wrong creating availability`)
       }
-
-      return upsertCatalogItemResponse.catalog_object.id
     }
   })
   .addResolver({
@@ -553,164 +573,164 @@ ItemTC.addResolver({
     resolve: async ({ args }) => {
       const { products, availabilityId } = args
 
-      const api = new CatalogApi()
+      const catalogApi = squareClient.catalogApi
 
-      const batchRetrieveCatalogObjectsResponse = await api.batchRetrieveCatalogObjects(
-        {
+      try {
+        const {
+          result: { objects: catalogObjects }
+        } = await catalogApi.batchRetrieveCatalogObjects({
           object_ids: products
-        }
-      )
+        })
 
-      const upsertBatchObjects = batchRetrieveCatalogObjectsResponse.objects.map(
-        product => ({
+        const upsertBatchObjects = catalogObjects.map(product => ({
           id: product.id,
           type: 'ITEM',
           version: product.version,
-          item_data: product.item_data,
-          custom_attribute_values: {
+          itemData: product.itemData,
+          customAttributeValues: {
             is_available: {
               name: 'Is it available?',
               key: 'is_available',
-              custom_attribute_definition_id: availabilityId,
+              customAttributeDefinitionId: availabilityId,
               type: 'BOOLEAN',
-              boolean_value: true
+              booleanValue: true
             }
           }
-        })
-      )
+        }))
 
-      const batchUpsertCatalogObjectsResponse = await api.batchUpsertCatalogObjects(
-        {
-          idempotency_key: uuid(),
+        const {
+          result: { objects }
+        } = await catalogApi.batchUpsertCatalogObjects({
+          idempotencyKey: uuid(),
           batches: [
             {
               objects: upsertBatchObjects
             }
           ]
-        }
-      )
-
-      const { objects } = batchUpsertCatalogObjectsResponse
-
-      // Step 1.5: Filter objects into distinct sets
-      const categories = objects.filter(object => object.type === 'CATEGORY')
-      const modifierLists = objects.filter(
-        object => object.type === 'MODIFIER_LIST'
-      )
-      const items = objects.filter(object => object.type === 'ITEM')
-
-      // Step 1.7: Extract category names from categories
-      const categoryId2Name = id =>
-        categories.find(category => category.id === id).category_data.name
-      const modifierListId2Data = id =>
-        modifierLists.find(modifierList => modifierList.id === id)
-
-      // Step 2: Transform data into CMD
-      return items.map(item => {
-        const {
-          id: itemId,
-          item_data: {
-            name: baseItemName,
-            description: baseItemDescription,
-            variations,
-            modifier_list_info,
-            category_id
-          },
-          custom_attribute_values: {
-            is_available: { boolean_value: isAvailable }
-          }
-        } = item
-
-        // Step 2.25: Replace category IDs with names
-        const categoryName = categoryId2Name(category_id)
-
-        const returnedVariants = variations.map(variant => {
-          const {
-            id: itemVariationId,
-            item_variation_data: {
-              item_id: parentItemId,
-              name: itemVariationName,
-              price_money
-            }
-          } = variant
-
-          return {
-            dataSourceId: itemVariationId,
-            parentItemId,
-            // Some variants do not have an associated price
-            price: {
-              amount: price_money ? price_money.amount : 0,
-              currency: price_money ? price_money.currency : 'USD'
-            },
-            // From interface
-            name: itemVariationName,
-            dataSource,
-            merchant: ''
-          }
         })
 
-        const modifierLists = modifier_list_info
-          ? modifier_list_info.map(info =>
-              modifierListId2Data(info.modifier_list_id)
-            )
-          : []
+        // Filter objects into distinct sets
+        const categories = objects.filter(object => object.type === 'CATEGORY')
+        const modifierLists = objects.filter(
+          object => object.type === 'MODIFIER_LIST'
+        )
+        const items = objects.filter(object => object.type === 'ITEM')
 
-        const returnedModifierLists = modifierLists.map(modifierList => {
+        // Define functions for getting category and modifier list data from id
+        const categoryId2Name = id =>
+          categories.find(category => category.id === id).category_data.name
+        const modifierListId2Data = id =>
+          modifierLists.find(modifierList => modifierList.id === id)
+
+        // Get fields for GraphQL response
+        return items.map(item => {
           const {
-            id: parentListId,
-            modifier_list_data: {
-              name: modifierListName,
-              selection_type,
-              modifiers
+            id: itemId,
+            itemData: {
+              name: baseItemName,
+              description: baseItemDescription,
+              variations,
+              modifierListInfo,
+              categoryId
+            },
+            customAttributeValues: {
+              is_available: { booleanValue: isAvailable }
             }
-          } = modifierList
+          } = item
 
-          const returnedModifiers = modifiers.map(modifier => {
+          const categoryName = categoryId2Name(categoryId)
+
+          const returnedVariants = variations.map(variant => {
             const {
-              id: modifierId,
-              modifier_data: {
-                name: modifierName,
-                modifier_list_id,
-                price_money
+              id: itemVariationId,
+              itemVariationData: {
+                itemId: parentItemId,
+                name: itemVariationName,
+                priceMoney
               }
-            } = modifier
+            } = variant
 
             return {
-              dataSourceId: modifierId,
-              parentListId: modifier_list_id,
-              // Some modifiers do not have an associated price
+              dataSourceId: itemVariationId,
+              parentItemId,
               price: {
-                amount: price_money ? price_money.amount : 0,
-                currency: price_money ? price_money.currency : 'USD'
+                amount: priceMoney ? priceMoney.amount : 0,
+                currency: priceMoney ? priceMoney.currency : 'USD'
               },
-              // For interface
-              name: modifierName,
-              dataSource,
+              name: itemVariationName,
+              dataSource: 'SQUARE',
               merchant: ''
             }
           })
 
+          const modifierLists = modifierListInfo
+            ? modifierListInfo.map(info => ({
+                data: modifierListId2Data(info.modifierListId),
+                min: info.minSelectedModifiers,
+                max: info.maxSelectedModifiers
+              }))
+            : []
+
+          const returnedModifierLists = modifierLists.map(modifierList => {
+            const {
+              id: parentListId,
+              modifierListData: {
+                name: modifierListName,
+                selectionType,
+                modifiers
+              }
+            } = modifierList.data
+
+            const returnedModifiers = modifiers.map(modifier => {
+              const {
+                id: modifierId,
+                modifierData: { name: modifierName, modifierListId, priceMoney }
+              } = modifier
+
+              return {
+                dataSourceId: modifierId,
+                parentListId: modifierListId,
+                price: {
+                  amount: priceMoney ? priceMoney.amount : 0,
+                  currency: priceMoney ? priceMoney.currency : 'USD'
+                },
+                name: modifierName,
+                dataSource: 'SQUARE',
+                merchant: ''
+              }
+            })
+
+            return {
+              dataSourceId: parentListId,
+              name: modifierListName,
+              selectionType: selectionType,
+              modifiers: returnedModifiers,
+              minModifiers: modifierList.min,
+              maxModifiers: modifierList.max
+            }
+          })
+
           return {
-            dataSourceId: parentListId,
-            name: modifierListName,
-            selectionType: selection_type,
-            modifiers: returnedModifiers
+            dataSourceId: itemId,
+            category: categoryName,
+            variants: returnedVariants,
+            modifierLists: returnedModifierLists,
+            dataSource: 'SQUARE',
+            name: baseItemName,
+            description: baseItemDescription,
+            merchant: '',
+            isAvailable: isAvailable
           }
         })
-
-        return {
-          dataSourceId: itemId,
-          category: categoryName,
-          variants: returnedVariants,
-          modifierLists: returnedModifierLists,
-          // From interface
-          dataSource,
-          name: baseItemName,
-          description: baseItemDescription,
-          merchant: '',
-          isAvailable: isAvailable
+      } catch (error) {
+        if (error instanceof ApiError) {
+          return new ApolloError(
+            `Creating availability toggle using Square failed because ${error.result}`
+          )
         }
-      })
+
+        return new ApolloError(`Something went wrong creating availability`)
+      }
     }
   })
 

--- a/api/src/square.js
+++ b/api/src/square.js
@@ -1,15 +1,9 @@
-import { ApiClient } from 'square-connect'
+import { Client, Environment } from 'square'
 import { SQUARE_ACCESS_TOKEN } from './config'
 
-// For Square Integration
+const squareClient = new Client({
+  environment: Environment.Sandbox,
+  accessToken: SQUARE_ACCESS_TOKEN
+})
 
-export const defaultClient = ApiClient.instance
-
-// Set sandbox url
-defaultClient.basePath = 'https://connect.squareupsandbox.com'
-
-// Configure OAuth2 access token for authorization: oauth2
-const { oauth2 } = defaultClient.authentications
-
-// Set sandbox access token
-oauth2.accessToken = SQUARE_ACCESS_TOKEN
+export default squareClient

--- a/client/src/Pages/User/Cart/util.js
+++ b/client/src/Pages/User/Cart/util.js
@@ -57,7 +57,7 @@ export const CREATE_ORDER = gql`
         name
         quantity
         modifiers {
-          catalog_object_id
+          catalogObjectId
         }
       }
     }

--- a/client/src/Pages/Vendor/VendorComponents/ClosedOrderComponents/ClosedOrderDashboard.js
+++ b/client/src/Pages/Vendor/VendorComponents/ClosedOrderComponents/ClosedOrderDashboard.js
@@ -27,11 +27,11 @@ const GET_COMPLETED_ORDERS = gql`
         items {
           name
           quantity
-          variation_name
+          variationName
           modifiers {
             name
           }
-          total_money {
+          totalMoney {
             amount
           }
         }

--- a/client/src/Pages/Vendor/VendorComponents/ItemsComponents/CatalogDisplayComponents.js
+++ b/client/src/Pages/Vendor/VendorComponents/ItemsComponents/CatalogDisplayComponents.js
@@ -88,7 +88,6 @@ function MakeCatalogItems (props) {
           onChange={e => {
             setAvailability({
               variables: {
-                idempotencyKey: uuid(),
                 productId: props.itemId,
                 isItemAvailable: e.target.checked
               }

--- a/client/src/Pages/Vendor/VendorComponents/OpenOrderComponents/OrderCard.js
+++ b/client/src/Pages/Vendor/VendorComponents/OpenOrderComponents/OrderCard.js
@@ -540,8 +540,8 @@ function OrderCard (props) {
               <MakeOrderDetails
                 quantity={item.quantity}
                 itemName={item.name}
-                price={item.total_money.amount / 100}
-                variant={item.variation_name}
+                price={item.totalMoney.amount / 100}
+                variant={item.variationName}
                 // modifiers={[...item.modifiers.name].join(', ')}
               />
             ))}

--- a/client/src/Pages/Vendor/VendorComponents/OpenOrderComponents/OrderDashboard.js
+++ b/client/src/Pages/Vendor/VendorComponents/OpenOrderComponents/OrderDashboard.js
@@ -27,20 +27,20 @@ const FIND_ORDERS = gql`
         items {
           name
           quantity
-          variation_name
+          variationName
           modifiers {
             name
-            base_price_money {
+            basePriceMoney {
               amount
             }
-            total_price_money {
+            totalPriceMoney {
               amount
             }
           }
-          total_money {
+          totalMoney {
             amount
           }
-          total_tax {
+          totalTax {
             amount
           }
         }
@@ -94,20 +94,20 @@ const ORDER_CREATED = gql`
       items {
         name
         quantity
-        variation_name
+        variationName
         modifiers {
           name
-          base_price_money {
+          basePriceMoney {
             amount
           }
-          total_price_money {
+          totalPriceMoney {
             amount
           }
         }
-        total_money {
+        totalMoney {
           amount
         }
-        total_tax {
+        totalTax {
           amount
         }
       }
@@ -143,20 +143,20 @@ const ORDER_UPDATED = gql`
       items {
         name
         quantity
-        variation_name
+        variationName
         modifiers {
           name
-          base_price_money {
+          basePriceMoney {
             amount
           }
-          total_price_money {
+          totalPriceMoney {
             amount
           }
         }
-        total_money {
+        totalMoney {
           amount
         }
-        total_tax {
+        totalTax {
           amount
         }
       }

--- a/client/src/graphql/ProductQueries.js
+++ b/client/src/graphql/ProductQueries.js
@@ -66,12 +66,10 @@ const GET_ITEM_AVAILABILITY = gql`
 
 const SET_ITEM_AVAILABILITY = gql`
   mutation SET_ITEM_AVAILABILITY(
-    $idempotencyKey: String!
     $productId: String!
     $isItemAvailable: Boolean!
   ) {
     setAvailability(
-      idempotencyKey: $idempotencyKey
       productId: $productId
       isItemAvailable: $isItemAvailable
       dataSource: SQUARE


### PR DESCRIPTION
The Square Connect SDK has reached EOL as of January 2021. It is replaced by the new Square Node SDK. The porting process mostly involved a lot of renaming because Square changed all their snake case names to camel case. Otherwise, everything should work mostly like it did before.

@newton-huynh If you could test all your usual stuff on this branch to verify that it actually works.